### PR TITLE
Fix Carousel transitions

### DIFF
--- a/scss/bootstrap-core/_carousel.scss
+++ b/scss/bootstrap-core/_carousel.scss
@@ -45,11 +45,13 @@
 .carousel-item-next:not(.carousel-item-left),
 .active.carousel-item-right {
   transform: translateX(100%);
+  z-index: 1;
 }
 
 .carousel-item-prev:not(.carousel-item-right),
 .active.carousel-item-left {
   transform: translateX(-100%);
+  z-index: 1;
 }
 
 
@@ -67,15 +69,12 @@
   .carousel-item.active,
   .carousel-item-next.carousel-item-left,
   .carousel-item-prev.carousel-item-right {
-    z-index: 1;
     opacity: 1;
   }
 
   .active.carousel-item-left,
   .active.carousel-item-right {
-    z-index: 0;
     opacity: 0;
-    @include transition(opacity 0s $carousel-transition-duration);
   }
 }
 

--- a/scss/bootstrap-core/_carousel.scss
+++ b/scss/bootstrap-core/_carousel.scss
@@ -45,13 +45,11 @@
 .carousel-item-next:not(.carousel-item-left),
 .active.carousel-item-right {
   transform: translateX(100%);
-  z-index: 1;
 }
 
 .carousel-item-prev:not(.carousel-item-right),
 .active.carousel-item-left {
   transform: translateX(-100%);
-  z-index: 1;
 }
 
 
@@ -69,12 +67,15 @@
   .carousel-item.active,
   .carousel-item-next.carousel-item-left,
   .carousel-item-prev.carousel-item-right {
+    z-index: 1;
     opacity: 1;
   }
 
   .active.carousel-item-left,
   .active.carousel-item-right {
+    z-index: 0;
     opacity: 0;
+    @include transition(opacity 0s $carousel-transition-duration);
   }
 }
 

--- a/scss/styles/_carousel.scss
+++ b/scss/styles/_carousel.scss
@@ -1,15 +1,20 @@
 @import "../bootstrap-core/carousel";
 
+/**
+ * TODO: This fixes the default `slide` transition, should be removed when it's fixed in Bootstrap
+ * See Pull request [#315](https://github.com/sebgroup/bootstrap/pull/315)
+ */
 .carousel-item-next:not(.carousel-item-left),
-.active.carousel-item-right {
-  z-index: 1;
-}
-
 .carousel-item-prev:not(.carousel-item-right),
+.active.carousel-item-right,
 .active.carousel-item-left {
   z-index: 1;
 }
 
+/**
+ * TODO: This fixes the `fade` transition, should be removed when it's fixed in Bootstrap
+ * See Pull request [#315](https://github.com/sebgroup/bootstrap/pull/315)
+ */
 .carousel-fade {
     .carousel-item {
         display: block;

--- a/scss/styles/_carousel.scss
+++ b/scss/styles/_carousel.scss
@@ -16,7 +16,25 @@
  * See Pull request [#315](https://github.com/sebgroup/bootstrap/pull/315)
  */
 .carousel-fade {
-    .carousel-item {
-        display: block;
+  .carousel-item {
+    &.carousel-item-next.carousel-item-left,
+    &.carousel-item-prev.carousel-item-right {
+      animation: fade-in $carousel-transition-duration forwards;
     }
+  }
+}
+
+@keyframes fade-in {
+  0% {
+    display: none;
+    opacity: 0;
+  }
+  1% {
+    display: block;
+    opacity: 0;
+  }
+  100% {
+    display: block;
+    opacity: 1;
+  }
 }

--- a/scss/styles/_carousel.scss
+++ b/scss/styles/_carousel.scss
@@ -1,1 +1,17 @@
 @import "../bootstrap-core/carousel";
+
+.carousel-item-next:not(.carousel-item-left),
+.active.carousel-item-right {
+  z-index: 1;
+}
+
+.carousel-item-prev:not(.carousel-item-right),
+.active.carousel-item-left {
+  z-index: 1;
+}
+
+.carousel-fade {
+    .carousel-item {
+        display: block;
+    }
+}


### PR DESCRIPTION
Currently, the carousel doesn't transition as it should be. The fix is to add a higher `z-index` for the **sliding-out item**. The remaining item is going to be visible anyway and the sliding-out item is going to leave the view and must stay visible until it's left the view.

## Slide
Default transition
![slide-1](https://user-images.githubusercontent.com/10633734/79954965-b4c2d780-84b0-11ea-954f-3d6414226ba9.gif)

Fixed transition
![slide-2](https://user-images.githubusercontent.com/10633734/79955130-eb005700-84b0-11ea-8da8-519bf4cb2332.gif)

## Fade
The issue also exists in the alternative fade transition. The fix is to set `display` to `block` for `carousel-item` in general. Since transitions won't work if `display` is set to `none`

Default transition 
![fade-1](https://user-images.githubusercontent.com/10633734/79955312-34e93d00-84b1-11ea-8999-1b6a09dd8bc8.gif)

Fixed transition 
![fade-2](https://user-images.githubusercontent.com/10633734/79955322-3c104b00-84b1-11ea-99c8-8e1c71735657.gif)
