### PR TITLE
refactor/close-button

### DIFF
--- a/scss/styles/_close.scss
+++ b/scss/styles/_close.scss
@@ -1,132 +1,20 @@
-// @import "../bootstrap-core/close";
-
 .close {
-  float: right;
-  @include font-size($close-font-size);
-  font-weight: $close-font-weight;
-  line-height: 1;
-  color: $close-color;
-  text-shadow: $close-text-shadow;
-  position: relative;
-  width: 2rem;
-  // opacity: .5;
-
-  // Override <a>'s hover style
-  @include hover() {
-    color: $close-color;
+    border: none;
+    box-shadow: none;
+    background: transparent;
+    border-radius: 50%;
+    line-height: 0;
+    padding: 0.5em;
     text-decoration: none;
-  }
+    transition: background-color 200ms, color 200ms;
 
-  /*&:not(:disabled):not(.disabled) {
-    @include hover-focus() {
-      opacity: .75;
+    &:hover:not(:disabled) {
+        background-color: rgba($gray-600, 0.4);
     }
-  }*/
 
-  &::before {
-    content: '';
-    background: escape-svg($close-icon);
-    background-size: 1rem;
-    background-position: 50%;
-    background-repeat: no-repeat;
-    padding: 1.375rem;
-    position: absolute;
-    top: -.375rem;
-    left: -.375rem;
-    z-index: 1;
-  }
-  span {
-    display: none;
-  }
-
-  &:not(:disabled):not(.disabled) {
-    @include hover-focus() {
-      &::after {
-        content: '';
-        background: $close-icon-hover-bg;
-        border-radius: 50%;
-        height: 2rem;
-        width: 2rem;
-        display: block;
-        position: absolute;
-        top: 0;
-        left: 0;
-        z-index: 0;
-        @include add-transition('fadeIn');
-        opacity: 1;
-      }
+    &::after {
+        content: "\2715";
+        line-height: 0.8em;
+        display: inline-block;
     }
-    &:active::after {
-      content: '';
-      background: $close-icon-active-bg;
-      border-radius: 50%;
-      height: 2rem;
-      width: 2rem;
-      display: block;
-      position: absolute;
-      top: 0;
-      left: 0;
-      z-index: 0;
-      @include add-transition('fadeIn');
-      opacity: 1;
-    }
-  }
-  /* smartphones, touchscreens */
-  @media (hover: none) and (pointer: coarse) {
-    &:not(:disabled):not(.disabled) {
-      &::after {
-        content: '';
-        background: $close-icon-hover-bg;
-        border-radius: 50%;
-        height: 2rem;
-        width: 2rem;
-        display: block;
-        position: absolute;
-        top: 0;
-        left: 0;
-        z-index: 0;
-        opacity: 1;
-      }
-    }
-  }
 }
-
-// Additional properties for button version
-// iOS requires the button element instead of an anchor tag.
-// If you want the anchor version, it requires `href="#"`.
-// See https://developer.mozilla.org/en-US/docs/Web/Events/click#Safari_Mobile
-
-// stylelint-disable-next-line selector-no-qualifying-type
-button.close {
-  padding: 0;
-  background-color: transparent;
-  border: 0;
-}
-
-// Future-proof disabling of clicks on `<a>` elements
-
-// stylelint-disable-next-line selector-no-qualifying-type
-a.close.disabled {
-  pointer-events: none;
-}
-
-
-/*button.close {
-  &::before {
-    content: '';
-    background: escape-svg($close-icon);
-    background-size: 1rem;
-    background-position: 50%;
-    background-repeat: no-repeat;
-    padding: 1.375rem;
-    position: absolute;
-    top: -.375rem;
-    left: -.375rem;
-    z-index: 1;
-  }
-  span {
-    display: none;
-  }
-}*/
-
-

--- a/scss/styles/_close.scss
+++ b/scss/styles/_close.scss
@@ -12,7 +12,7 @@
     &:not(:disabled) {
         &:hover,
         &:focus {
-            background-color: rgba($gray-600, 0.4);
+            background-color: rgba($gray-600, 0.2);
         }
     }
 

--- a/scss/styles/_close.scss
+++ b/scss/styles/_close.scss
@@ -1,6 +1,5 @@
 .close {
     border: none;
-    outline: none;
     box-shadow: none;
     background: transparent;
     border-radius: 50%;
@@ -11,8 +10,11 @@
 
     &:not(:disabled) {
         &:hover,
-        &:focus {
+        &:active {
             background-color: rgba($gray-600, 0.2);
+        }
+        &:active {
+            color: white;
         }
     }
 

--- a/scss/styles/_close.scss
+++ b/scss/styles/_close.scss
@@ -1,5 +1,6 @@
 .close {
     border: none;
+    outline: none;
     box-shadow: none;
     background: transparent;
     border-radius: 50%;
@@ -8,8 +9,11 @@
     text-decoration: none;
     transition: background-color 200ms, color 200ms;
 
-    &:hover:not(:disabled) {
-        background-color: rgba($gray-600, 0.4);
+    &:not(:disabled) {
+        &:hover,
+        &:focus {
+            background-color: rgba($gray-600, 0.4);
+        }
     }
 
     &::after {


### PR DESCRIPTION
### Description
This PR is to address an issue with the close button (`.close`) which is the lack of flexibility when it comes to switching its color and size.

---

### Benefits
This PR comes with the following benefits:

- [x] Replacing a background SVG with the widely supported HTML Symbols (in this case: `U+02715`).
- [x] Flexibility in switching the color since the `x` follows the `currentColor` property.
- [x] Flexibility in scaling since both the `x` and the halo follows it's parent's `em` sizing.
- [x] A fewer lines of code.
- [x] Transparent halo background allows it to blend better if it's rendered in coloured backgrounds.

---

### Screenshots
![ezgif-1-afc92a603f5a](https://user-images.githubusercontent.com/10633734/104274781-938d9580-54dc-11eb-9d66-9d83e446bfea.gif)

### What I've considered as alternative
As of now, the only way possible for me to change the color of the existing close button is by inverting the background using a filter which is not optimum. Especially when you want to use a color other than black and white.
```css
filter: invert(1);
```