### PR TITLE
chore(deps): bump Bootstrap to v4.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "autoprefixer": "^9.8.6",
         "backstopjs": "^5.3.5",
         "body-scroll-lock": "^3.1.5",
-        "bootstrap": "^4.6.0",
+        "bootstrap": "^4.6.2",
         "clean-css-cli": "^4.2.1",
         "codelyzer": "^6.0.2",
         "commitizen": "^2.10.1",
@@ -7514,14 +7514,21 @@
       "dev": true
     },
     "node_modules/bootstrap": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.1.tgz",
-      "integrity": "sha512-0dj+VgI9Ecom+rvvpNZ4MUZJz8dcX7WCX+eTID9+/8HgOkv3dsRzi8BGeZJCQU6flWQVYxwTQnEZFrmJSEO7og==",
+      "version": "4.6.2",
+      "resolved": "https://repo.sebank.se:443/artifactory/api/npm/seb-npm/bootstrap/-/bootstrap-4.6.2.tgz",
+      "integrity": "sha1-jgzWFhFyilv2WjorjW/2x31ddHk=",
       "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/bootstrap"
-      },
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
+      "license": "MIT",
       "peerDependencies": {
         "jquery": "1.9.1 - 3",
         "popper.js": "^1.16.1"
@@ -36908,9 +36915,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.1.tgz",
-      "integrity": "sha512-0dj+VgI9Ecom+rvvpNZ4MUZJz8dcX7WCX+eTID9+/8HgOkv3dsRzi8BGeZJCQU6flWQVYxwTQnEZFrmJSEO7og==",
+      "version": "4.6.2",
+      "resolved": "https://repo.sebank.se:443/artifactory/api/npm/seb-npm/bootstrap/-/bootstrap-4.6.2.tgz",
+      "integrity": "sha1-jgzWFhFyilv2WjorjW/2x31ddHk=",
       "dev": true,
       "requires": {}
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -7515,7 +7515,7 @@
     },
     "node_modules/bootstrap": {
       "version": "4.6.2",
-      "resolved": "https://repo.sebank.se:443/artifactory/api/npm/seb-npm/bootstrap/-/bootstrap-4.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.2.tgz",
       "integrity": "sha1-jgzWFhFyilv2WjorjW/2x31ddHk=",
       "dev": true,
       "funding": [
@@ -36916,7 +36916,7 @@
     },
     "bootstrap": {
       "version": "4.6.2",
-      "resolved": "https://repo.sebank.se:443/artifactory/api/npm/seb-npm/bootstrap/-/bootstrap-4.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.2.tgz",
       "integrity": "sha1-jgzWFhFyilv2WjorjW/2x31ddHk=",
       "dev": true,
       "requires": {}

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "autoprefixer": "^9.8.6",
     "backstopjs": "^5.3.5",
     "body-scroll-lock": "^3.1.5",
-    "bootstrap": "^4.6.0",
+    "bootstrap": "^4.6.2",
     "clean-css-cli": "^4.2.1",
     "codelyzer": "^6.0.2",
     "commitizen": "^2.10.1",


### PR DESCRIPTION
- this Bootstrap version fixes build warning arises from deprecated dependencies https://github.com/twbs/bootstrap/issues/36259